### PR TITLE
Fix LinkButton rounded border on safari

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -10,7 +10,7 @@ const { href, text, ...rest } = Astro.props;
 <a
   role="button"
   href={href}
-  class="mx-auto rounded px-2 py-1 text-base text-primary outline outline-1 hover:bg-violet-900 hover:text-default hover:outline-none"
+  class="mx-auto rounded border border-primary px-2 py-1 text-base text-primary transition hover:border-transparent hover:bg-violet-900 hover:text-default"
   {...rest}
   >{text}
 </a>


### PR DESCRIPTION
# Description of Changes
Fixes the border on the `LinkButton` component to actually be rounded on Safari
