### PR TITLE
Update build workflow to not run on push to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: build
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description of Changes
CI workflows should only run on PRs. The `build` workflow is currently running on the merge commits to master branch so this removes that event from the list of build triggers.
